### PR TITLE
Change oss_ressources.c

### DIFF
--- a/oss_resource.c
+++ b/oss_resource.c
@@ -60,13 +60,6 @@ int32 OSS_AssignResources(
 
 		case OSS_RES_MEM:
 			DBGWRT_2((DBH," MEM: phys=0x%p size=0x%x\n", r->u.mem.physAddr, r->u.mem.size ));
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
-			if( check_mem_region( (unsigned long)r->u.mem.physAddr, r->u.mem.size ))
-			{
-				error = ERR_OSS_BUSY_RESOURCE;
-				break;
-			}
-#endif
 			request_mem_region( (unsigned long)r->u.mem.physAddr,
 								r->u.mem.size, oss->instName );
 			break;
@@ -74,12 +67,6 @@ int32 OSS_AssignResources(
 		case OSS_RES_IO:
 			DBGWRT_2((DBH," IO: phys=0x%p size=0x%x\n",
 					  r->u.mem.physAddr, r->u.mem.size ));
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,0,0)
-			if( check_region( (unsigned long)r->u.mem.physAddr, r->u.mem.size )){
-				error = ERR_OSS_BUSY_RESOURCE;
-				break;
-			}
-#endif
 			request_region( (unsigned long)r->u.mem.physAddr, r->u.mem.size, oss->instName );
 			break;
 			


### PR DESCRIPTION
Concurrent accesses to a Low Level Driver like M66 and a native driver on the same BBIS on kernel older than 4.0.0 (typically the A21B) is not possible because check_mem_region says the region is already in use.
Removing the check of region allows both driver to run concurently.